### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Lighthouse
-        uses: shopify/lighthouse-ci-action
+        uses: shopify/lighthouse-ci-action@1.0
         with:
           app_id: ${{ secrets.SHOP_APP_ID }}
           app_password: ${{ secrets.SHOP_APP_PASSWORD }}
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Lighthouse
-        uses: shopify/lighthouse-ci-action
+        uses: shopify/lighthouse-ci-action@1.0
         with:
           app_id: ${{ secrets.SHOP_APP_ID }}
           app_password: ${{ secrets.SHOP_APP_PASSWORD }}
@@ -65,6 +65,7 @@ The `shopify/lighthouse-ci-action` accepts the following arguments:
 * `collection_handle` - (optional) Collection handle to run the product page Lighthouse run on. Defaults to the first collection.
 * `lhci_min_score_performance` - (optional, default: 0.6) Minimum performance score for a passed audit (must be between 0 and 1).
 * `lhci_min_score_accessibility` - (optional, default: 0.9) Minimum accessibility score for a passed audit
+* `theme_root` - (optional, default: '.') Path from repo root to the root fo the theme('dist').
 
 For the GitHub Status Checks on PR. One of the two arguments is required:
 


### PR DESCRIPTION
Update the readme to include the `theme_root` option and to include the `@1.0` version in examples(as this is needed to use the action)

In order for the `theme_root` option to actually be usable a release and version bump would be needed.