### PR TITLE
Switch to shopify-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: CI
+
+on: [push]
+
+jobs:
+  check_dawn:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "shopify/dawn"
+          path: "./dawn"
+
+      - name: Lighthouse CI action
+        uses: ./
+        id: lighthouse-ci-action
+        with:
+          app_id: ${{ secrets.SHOP_APP_ID }}
+          app_password: ${{ secrets.SHOP_APP_PASSWORD }}
+          store: shimmering-islands.myshopify.com
+          theme_root: "./dawn"
+          lhci_min_score_performance: 0.1
+          lhci_min_score_accessibility: 0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,18 @@
-FROM node:14
+FROM node:14-buster
 
 # Install dependencies
-RUN apt-get update && \
-      apt-get -y install sudo jq
+RUN apt-get update \
+    && apt-get -y install sudo jq rbenv
+
+ENV PATH="/root/.rbenv/shims:${PATH}"
+
+# install ruby + shopify-cli
+RUN mkdir -p "$(rbenv root)"/plugins \
+    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
+    && git -C "$(rbenv root)"/plugins/ruby-build pull \
+    && rbenv install 2.7.1 \
+    && rbenv global 2.7.1 \
+    && gem install shopify-cli -N
 
 ###
 # Chrome in Docker fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,3 @@
-FROM node:14-buster
-
-# Install dependencies
-RUN apt-get update \
-    && apt-get -y install sudo jq rbenv
-
-ENV PATH="/root/.rbenv/shims:${PATH}"
-
-# install ruby + shopify-cli
-RUN mkdir -p "$(rbenv root)"/plugins \
-    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
-    && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 2.7.1 \
-    && rbenv global 2.7.1 \
-    && gem install shopify-cli -N
-
-###
-# Chrome in Docker fix
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
-RUN mkdir -p "$npm_config_prefix" \
-  && chmod -R 777 "$npm_config_prefix" \
-  && umask 000 \
-  && npm install -g @lhci/cli@0.7.x puppeteer
-
+FROM cpclermont/lighthouse-ci-action:1.0.0
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,33 @@
+FROM node:14-buster
+
+ENV PATH="/root/.rbenv/shims:${PATH}"
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get -y install sudo jq rbenv \
+    && mkdir -p "$(rbenv root)"/plugins \
+    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
+    && git -C "$(rbenv root)"/plugins/ruby-build pull \
+    && rbenv install 2.7.1 \
+    && rbenv global 2.7.1 \
+    && gem install shopify-cli -N
+
+###
+# Chrome in Docker fix
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
+ENV PATH="$npm_config_prefix:${PATH}"
+RUN mkdir -p "$npm_config_prefix" \
+  && chmod -R 777 "$npm_config_prefix" \
+  && umask 000 \
+  && npm install -g @lhci/cli@0.8.x puppeteer

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+PROJECT_NAME := cpclermont/lighthouse-ci-action
+VERSION := 1.0.0
+GITSHA:= $(shell echo $$(git describe --always --long --dirty))
+
+export GITSHA
+export VERSION
+
+base: Dockerfile
+	DOCKER_BUILDKIT=1 docker build -t $(PROJECT_NAME):$(VERSION) -t $(PROJECT_NAME):$(GITSHA) - < Dockerfile.base
+
+push: base
+	docker push $(PROJECT_NAME):$(VERSION)
+
+runner: base
+	DOCKER_BUILDKIT=1 docker build -t $(PROJECT_NAME)-runner:$(VERSION) -t $(PROJECT_NAME)-runner:$(GITSHA) .
+
+ssh: runner
+	docker run -it --entrypoint /bin/bash $(PROJECT_NAME)-runner:$(VERSION)


### PR DESCRIPTION
In this PR, we move away from themekit and to shopify CLI for a couple of reasons:

1. Use development themes (these don't show up in admin and get
   cleaned up automatically after a period of inactivity (even though
   we do try to clean them up with a `shopify logout`))
2. Use `shopify push --development --json` to simplify the code a lot, making creating ephemeral themes faster with less chances of things blowing up.

Concerns:

<s>1. Installing ruby in the Docker image takes a lot of time and might make things slower overall. Would have to benchmark. Perhaps it would be worth creating and pushing our own docker image?</s>

I added a Dockerfile.base and a Makefile. I'm deploying those to dockerhub to download as base ([cpclermont/lighthouse-ci-action:1.0.0](https://hub.docker.com/r/cpclermont/lighthouse-ci-action)). This makes the install ruby + npm part (almost) instantaneous.

Leaving us with `shopify push --development --json $theme_root` as the primary bottleneck of this CI action. But it's still faster than themekit.

Fixes #4