### PR TITLE
Fill password form manually instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 on: [push]
 
 jobs:
-  check_dawn:
+  check_dawn_staff_store:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,6 +22,30 @@ jobs:
           app_password: ${{ secrets.SHOP_APP_PASSWORD }}
           store: shimmering-islands.myshopify.com
           product_handle: outdoor-sofa
+          collection_handle: frontpage
+          theme_root: "./dawn"
+          lhci_min_score_performance: 0.1
+          lhci_min_score_accessibility: 0.1
+
+  check_dawn_dev_store:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "shopify/dawn"
+          path: "./dawn"
+
+      - name: Lighthouse CI action
+        uses: ./
+        id: lighthouse-ci-action
+        with:
+          app_id: ${{ secrets.DEV_APP_ID }}
+          app_password: ${{ secrets.DEV_APP_PASSWORD }}
+          store: cpclermont-dev-store.myshopify.com
+          password: ${{ secrets.DEV_PASSWORD }}
+          product_handle: convertible-coffee-table
           collection_handle: frontpage
           theme_root: "./dawn"
           lhci_min_score_performance: 0.1


### PR DESCRIPTION
The /password?password=<pwd> trick doesn't work for development stores.

Instead, just fill the form and submit it.

Fixes #8
