### PR TITLE
Remove duplicate 'theme_root' entry in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ The `shopify/lighthouse-ci-action` accepts the following arguments:
 * `collection_handle` - (optional) Collection handle to run the product page Lighthouse run on. Defaults to the first collection.
 * `lhci_min_score_performance` - (optional, default: 0.6) Minimum performance score for a passed audit (must be between 0 and 1).
 * `lhci_min_score_accessibility` - (optional, default: 0.9) Minimum accessibility score for a passed audit
-* `theme_root` - (optional, default: '.') Path from repo root to the root fo the theme('dist').
 
 For the GitHub Status Checks on PR. One of the two arguments is required:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The `shopify/lighthouse-ci-action` accepts the following arguments:
 * `store` - (required) Shopify store `<domain>.myshopify.com` URL.
 * `password` - (optional) For password protected shops
 * `product_handle` - (optional) Product handle to run the product page Lighthouse run on. Defaults to the first product.
-* `theme_root` - (optional) The root folder for the theme assets that will be uploaded. Defaults to `.`
+* `theme_root` - (optional) The root folder for the theme files that will be uploaded. Defaults to `.`
 * `collection_handle` - (optional) Collection handle to run the product page Lighthouse run on. Defaults to the first collection.
 * `lhci_min_score_performance` - (optional, default: 0.6) Minimum performance score for a passed audit (must be between 0 and 1).
 * `lhci_min_score_accessibility` - (optional, default: 0.9) Minimum accessibility score for a passed audit

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'Collection handle for collection page test (default: first collection).'
     required: false
   theme_root:
-    description: 'The root folder for the theme assets that will be uploaded (default: ".")'
+    description: 'The root folder for the theme files that will be uploaded (default: ".")'
     required: false
     default: '.'
   lhci_github_app_token:


### PR DESCRIPTION
I've found that there are two entries in the `README.md` for the `theme_root` option. I wanted to clean this up along with suggest a slight amendment to the wording for this option.

The current description for `theme_root` specifies where "theme assets" will be uploaded, but this could be read ambiguously as the `assets/` folder for the theme. I would like to suggest using "theme files" instead as this language is more cohesive with what I have seen across other documentation such as Shopify CLI for Themes.