### PR TITLE
Delete the development theme

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,7 @@ api_request() {
 cleanup() {
   if [[ -n "${theme+x}" ]]; then
     step "Disposing development theme"
+    shopify theme delete -d -f
     shopify logout
   fi
 


### PR DESCRIPTION
Today I learned that the ephemeral development theme isn't deleted when you log out.  We ran into a 100 development theme limit and our CI started to fail.  I can log in and delete themes every now and then but it would be better if this was automated.  