### PR TITLE
Update query string to include theme id for development theme preview

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,6 +142,7 @@ step "Creating development theme"
 theme_push_log="$(mktemp)"
 shopify theme push --development --json $theme_root > "$theme_push_log" && cat "$theme_push_log"
 preview_url="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.preview_url')"
+preview_id="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.id')"
 
 step "Configuring Lighthouse CI"
 
@@ -164,7 +165,7 @@ else
 fi
 
 # Disable redirects + preview bar
-query_string="?_fd=0&pb=0"
+query_string="?preview_theme_id=$(echo "$preview_id")&_fd=0&pb=0"
 min_score_performance="${LHCI_MIN_SCORE_PERFORMANCE:-0.6}"
 min_score_accessibility="${LHCI_MIN_SCORE_ACCESSIBILITY:-0.9}"
 
@@ -204,7 +205,7 @@ module.exports = async (browser) => {
   // Get password cookie if password is set
   if ('$shop_password' !== '') {
     console.error('Getting password cookie...');
-    await page.goto('$host/password');
+    await page.goto('$host/password$query_string');
     await page.waitForSelector('form[action*=password] input[type="password"]');
     await page.\$eval('form[action*=password] input[type="password"]', input => input.value = '$shop_password');
     await Promise.all([


### PR DESCRIPTION
Fixes #18. Also fixes an issue with the Lighthouse CI returning only 1 report (of the password page itself).

Setup:
- Using a Custom App for authentication
- All standard variables set via GitHub Secrets
- I'm not using my Partner account for this Shopify Store (I'm using a staff account instead)

The problem:
- Lighthouse CI is running tests on the live store, not on the development store.
- The Lighthouse report is only showing results for the password page of the live store.

How this PR fixes the problem:
One of the main things I noticed, is that `$host` is the main Shopify store url, which ignores the new development store created by this action. That `$host` is being used on a few places where the development preview url is needed instead.

Maybe it was possible to use `$preview_url` instead of `$host`, but at the same time 1) the preview_url path differs for the index, products and collections; and 2) we need the `$query_string`.

Steps to fix the problem:
- When we push the development store and it returns the json, create a variable for the new theme id. - Added the theme id on the query string variable, with modifications `"?preview_theme_id=$(echo "$preview_id")&_fd=0&pb=0"`. **This will be used on the lighthouse action (around lines 172-198).**
- Then also added the query string (with the theme id) on the password page url if the store is password protected (lines 206-215), to make sure we're entering the password on the correct store preview.

Other considerations:
- I only tested this on one Shopify store
- The store tested is a development Shopify Plus store with password enabled
- Tested using a fresh Dawn Theme, although the Shopify store itself is not fresh
- I'm a front-end developer and my Git, GitHub Actions, node and docker knowledge is still under development. That said, the changes worked for me, so I wanted to share with the community.

Note: this is my first ever PR for a public repo, hooray!