### PR TITLE
[Enhancement] Update action to rely on Shopify CLI 3.x + Theme Access app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
             access_token: ''
             password: ''
 
-          - job_name: 'staff store, Theme Access app login'
-            store: shimmering-islands.myshopify.com
-            app_id: ''
-            app_password: ''
-            access_token: ''
-            password: ''
-            shopify_cli_theme_token: '........' # TODO: enter!
+          # - job_name: 'staff store, Theme Access app login'
+          #   store: shimmering-islands.myshopify.com
+          #   app_id: ''
+          #   app_password: ''
+          #   access_token: ''
+          #   password: ''
+          #   shopify_cli_theme_token: '........' # TODO: enter!
 
           - job_name: 'dev store, custom app login'
             store: cpclermont-dev-store.myshopify.com
@@ -45,13 +45,13 @@ jobs:
             access_token: ''
             password: DEV_PASSWORD
 
-          - job_name: 'dev store, Theme Access app login'
-            store: cpclermont-dev-store.myshopify.com
-            app_id: ''
-            app_password: ''
-            access_token: ''
-            password: ''
-            shopify_cli_theme_token: '........' # TODO: enter!
+          # - job_name: 'dev store, Theme Access app login'
+          #   store: cpclermont-dev-store.myshopify.com
+          #   app_id: ''
+          #   app_password: ''
+          #   access_token: ''
+          #   password: ''
+          #   shopify_cli_theme_token: '........' # TODO: enter!
 
     name: ${{ matrix.job_name }}
 
@@ -63,7 +63,7 @@ jobs:
           path: "./dawn"
 
       - name: Lighthouse CI action
-        # docker://ghcr.io/OWNER/IMAGE_NAME
+        # uses: docker://ghcr.io/shopify/lighthouse-ci-action:1.1.0
         uses: docker://cpclermont/lighthouse-ci-action:1.0.0
         id: lighthouse-ci-action
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,9 @@ jobs:
           path: "./dawn"
 
       - name: Lighthouse CI action
-        # uses: docker://ghcr.io/shopify/lighthouse-ci-action:1.1.0
-        uses: docker://cpclermont/lighthouse-ci-action:1.0.0
+        uses: ./
         id: lighthouse-ci-action
         with:
-          entrypoint: ./entrypoint.sh
           app_id: ${{ secrets[matrix.app_id] }}
           app_password: ${{ secrets[matrix.app_password] }}
           access_token: ${{ secrets[matrix.access_token] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Lighthouse CI action
         # docker://ghcr.io/OWNER/IMAGE_NAME
-        uses: docker://cpclermont/lighthouse-ci-action
+        uses: docker://cpclermont/lighthouse-ci-action:1.0.0
         id: lighthouse-ci-action
         with:
           entrypoint: ./entrypoint.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 name: CI
 
-on:
-  push:
-    branches:
-      - main
+on: [push]
 
 jobs:
   check_dawn:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
             access_token: ''
             password: ''
 
+          - job_name: 'staff store, Theme Access app login'
+            store: shimmering-islands.myshopify.com
+            app_id: ''
+            app_password: ''
+            access_token: ''
+            password: ''
+            shopify_cli_theme_token: '........' # TODO: enter!
+
           - job_name: 'dev store, custom app login'
             store: cpclermont-dev-store.myshopify.com
             app_id: ''
@@ -37,6 +45,14 @@ jobs:
             access_token: ''
             password: DEV_PASSWORD
 
+          - job_name: 'dev store, Theme Access app login'
+            store: cpclermont-dev-store.myshopify.com
+            app_id: ''
+            app_password: ''
+            access_token: ''
+            password: ''
+            shopify_cli_theme_token: '........' # TODO: enter!
+
     name: ${{ matrix.job_name }}
 
     steps:
@@ -47,9 +63,11 @@ jobs:
           path: "./dawn"
 
       - name: Lighthouse CI action
-        uses: ./
+        # docker://ghcr.io/OWNER/IMAGE_NAME
+        uses: docker://cpclermont/lighthouse-ci-action
         id: lighthouse-ci-action
         with:
+          entrypoint: ./entrypoint.sh
           app_id: ${{ secrets[matrix.app_id] }}
           app_password: ${{ secrets[matrix.app_password] }}
           access_token: ${{ secrets[matrix.access_token] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   check_dawn:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,33 @@
-FROM cpclermont/lighthouse-ci-action:1.0.0
+FROM ruby:3
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get -y install sudo jq chromium
+
+# Use latest bundler version so that Shopify CLI does not complain
+RUN gem install bundler -N
+
+# Install Shopify CLI 2.x
+RUN gem install shopify-cli -N
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get install -y nodejs
+
+# See https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#global-npm-dependencies
+# for reasons why we need to set `npm_config_prefix`.
+ENV npm_config_prefix="${GITHUB_WORKSPACE:-/home}/.node"
+ENV PATH="$npm_config_prefix:${PATH}"
+
+# Install Shopify CLI 3.x
+RUN npm install -g @shopify/cli @shopify/theme puppeteer @lhci/cli
+
+# Chrome in Docker fix
+# Install latest fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+RUN apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,4 @@
-FROM ruby:3
-
-# Install dependencies
-RUN apt-get update \
-    && apt-get -y install sudo jq chromium
-
-# Use latest bundler version so that Shopify CLI does not complain
-RUN gem install bundler -N
-
-# Install Shopify CLI 2.x
-RUN gem install shopify-cli -N
-
-# Install Node.js
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
-
-# See https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#global-npm-dependencies
-# for reasons why we need to set `npm_config_prefix`.
-ENV npm_config_prefix="${GITHUB_WORKSPACE:-/home}/.node"
-ENV PATH="$npm_config_prefix:${PATH}"
-
-# Install Shopify CLI 3.x
-RUN npm install -g @shopify/cli @shopify/theme puppeteer @lhci/cli
-
-# Chrome in Docker fix
-# Install latest fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
-RUN apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
+FROM ghcr.io/shopify/lighthouse-ci-action:1.1.0
+LABEL org.opencontainers.image.source https://github.com/Shopify/lighthouse-ci-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,33 +1,30 @@
-FROM node:14-buster
-
-ENV PATH="/root/.rbenv/shims:${PATH}"
+FROM ruby:3
 
 # Install dependencies
 RUN apt-get update \
-    && apt-get -y install sudo jq rbenv \
-    && mkdir -p "$(rbenv root)"/plugins \
-    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
-    && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 2.7.1 \
-    && rbenv global 2.7.1 \
-    && gem install shopify-cli -N
+  && apt-get -y install sudo jq chromium
 
-###
-# Chrome in Docker fix
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+# Use latest bundler version so that Shopify CLI does not complain
+RUN gem install bundler -N
 
-ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
+# Install Shopify CLI 2.x
+RUN gem install shopify-cli -N
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get install -y nodejs
+
+# See https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#global-npm-dependencies
+# for reasons why we need to set `npm_config_prefix`.
+ENV npm_config_prefix="${GITHUB_WORKSPACE:-/home}/.node"
 ENV PATH="$npm_config_prefix:${PATH}"
-RUN mkdir -p "$npm_config_prefix" \
-  && chmod -R 777 "$npm_config_prefix" \
-  && umask 000 \
-  && npm install -g @lhci/cli@0.8.x puppeteer
+
+# Install Shopify CLI 3.x
+RUN npm install -g @shopify/cli @shopify/theme puppeteer @lhci/cli
+
+# Chrome in Docker fix
+# Install latest fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+RUN apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+  --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,30 @@
-PROJECT_NAME := cpclermont/lighthouse-ci-action
-VERSION := 1.0.0
-GITSHA:= $(shell echo $$(git describe --always --long --dirty))
+USER_NAME := shopify
+PROJECT_NAME := $(USER_NAME)/lighthouse-ci-action
+VERSION := 1.1.0
+GITSHA := $(shell echo $$(git describe --always --long --dirty))
+DOCKER_COMMAND := podman
+PACKAGE_REGISTRY_URL := ghcr.io
 
 export GITSHA
 export VERSION
 
+# Make sure to create an access token and save it under `CR_PAT` before running the login command. Instructions:
+# https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+# You will need scopes `read:packages`, `write:packages`, `delete:packages`
+
 base: Dockerfile
-	DOCKER_BUILDKIT=1 docker build -t $(PROJECT_NAME):$(VERSION) -t $(PROJECT_NAME):$(GITSHA) - < Dockerfile.base
+	DOCKER_BUILDKIT=1 $(DOCKER_COMMAND) build -t $(PROJECT_NAME):$(VERSION) -t $(PROJECT_NAME):$(GITSHA) - < Dockerfile.base
+
+login:
+	echo $(CR_PAT) | $(DOCKER_COMMAND) login $(PACKAGE_REGISTRY_URL) -u $(USER_NAME) --password-stdin
 
 push: base
-	docker push $(PROJECT_NAME):$(VERSION)
+	$(DOCKER_COMMAND) push $(PROJECT_NAME):$(VERSION) $(PACKAGE_REGISTRY_URL)/$(PROJECT_NAME)
 
 runner: base
-	DOCKER_BUILDKIT=1 docker build -t $(PROJECT_NAME)-runner:$(VERSION) -t $(PROJECT_NAME)-runner:$(GITSHA) .
+	DOCKER_BUILDKIT=1 $(DOCKER_COMMAND) build -t $(PROJECT_NAME)-runner:$(VERSION) -t $(PROJECT_NAME)-runner:$(GITSHA) .
 
 ssh: runner
-	docker run -it --entrypoint /bin/bash $(PROJECT_NAME)-runner:$(VERSION)
+	$(DOCKER_COMMAND) run -it --entrypoint /bin/bash $(PROJECT_NAME)-runner:$(VERSION)
+
+# echo $CR_PAT | docker/podman login ghcr.io -u shopify --password-stdin

--- a/README.md
+++ b/README.md
@@ -32,18 +32,10 @@ jobs:
 
 ## Authentication
 
-Authentication is done with [Custom App access tokens](https://shopify.dev/apps/auth/admin-app-access-tokens).
-
-1. [Create the app](https://help.shopify.com/en/manual/apps/custom-apps#create-and-install-a-custom-app).
-2. Click the `Configure Admin API Scopes` button.
-3. Enable the following scopes:
-   - `read_products`
-   - `write_themes`
-4. Click `Save`.
-5. From the `API credentials` tab, install the app.
-6. Take note of the `Admin API access token`.
-7. Add the following to your repository's [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-environment):
-   - `SHOP_ACCESS_TOKEN`: the Admin API access token
+1. Follow the steps to [install the Theme Access app](https://shopify.dev/themes/tools/theme-access#install-the-theme-access-app)
+2. Follow the steps to [create a password](https://shopify.dev/themes/tools/theme-access#create-a-password)
+3. Add the following to your repository's [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-environment):
+   - `SHOPIFY_CLI_THEME_TOKEN`: the Theme Access app password
    - `SHOP_STORE`: Shopify store `<store>.myshopify.com` URL
 
 ## Configuration
@@ -66,9 +58,28 @@ For the GitHub Status Checks on PR. One of the two arguments is required:
 
 For more details on the implications of choosing one over the other, refer to the [Lighthouse CI Getting Started Page](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/getting-started.md#github-status-checks)
 
-### Deprecated authentication configuration
+## Docker Image Registry on GitHub
+Docker image is hosted on [GitHub packages](ghcr.io).
+
+See [Package configuration on GitHub](https://github.com/orgs/Shopify/packages/container/lighthouse-ci-action/settings) for more details.
+
+### Deprecated authentication configurations
 
 The following were used to authenticate with private apps.
 
 * `app_id` - (deprecated) Shopify store private app ID.
 * `app_password` - (deprecated) Shopify store private app password.
+
+Another deprecated authentication method is with [Custom App access tokens](https://shopify.dev/apps/auth/admin-app-access-tokens).
+
+1. [Create the app](https://help.shopify.com/en/manual/apps/custom-apps#create-and-install-a-custom-app).
+2. Click the `Configure Admin API Scopes` button.
+3. Enable the following scopes:
+   - `read_products`
+   - `write_themes`
+4. Click `Save`.
+5. From the `API credentials` tab, install the app.
+6. Take note of the `Admin API access token`.
+7. Add the following to your repository's [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-environment):
+   - `SHOP_ACCESS_TOKEN`: the Admin API access token
+   - `SHOP_STORE`: Shopify store `<store>.myshopify.com` URL

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ branding:
   colour: green
 description: 'Run Lighthouse CI on Shopify themes directly from GitHub'
 inputs:
-  access_token:
-    description: 'Custom app access token'
+  shopify_cli_theme_token:
+    description: 'Theme Access app token'
     # required: false because you can still authenticate with private
-    # app credentials
+    # app credentials or custom app access token
     required: false
   store:
     description: '<domain>.myshopify.com URL'
@@ -42,11 +42,15 @@ inputs:
     default: 0.9
   app_id:
     description: '(deprecated) Shopify private app ID'
-    depreciationMessage: Shopify private apps are deprecated. Use a Custom App `access_token` instead.
+    depreciationMessage: Shopify private apps are deprecated. Use a Theme Access App `shopify_cli_theme_token` instead.
     required: false
   app_password:
     description: '(deprecated) Shopify private app password'
-    depreciationMessage: Shopify private apps are deprecated. Use a Custom App `access_token` instead.
+    depreciationMessage: Shopify private apps are deprecated. Use a Theme Access App `shopify_cli_theme_token` instead.
+    required: false
+  access_token:
+    description: '(deprecated) Custom app access token'
+    depreciationMessage: Custom app access tokens are deprecated. Use a Theme Access App `shopify_cli_theme_token` instead.
     required: false
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,12 +34,16 @@ export SHOP_ACCESS_TOKEN="$INPUT_ACCESS_TOKEN"
 [[ -n "$INPUT_LHCI_MIN_SCORE_PERFORMANCE" ]]   && export LHCI_MIN_SCORE_PERFORMANCE="$INPUT_LHCI_MIN_SCORE_PERFORMANCE"
 [[ -n "$INPUT_LHCI_MIN_SCORE_ACCESSIBILITY" ]] && export LHCI_MIN_SCORE_ACCESSIBILITY="$INPUT_LHCI_MIN_SCORE_ACCESSIBILITY"
 
+log() {
+  echo "$@" 1>&2
+}
+
 # Add global node bin to PATH (from the Dockerfile)
 if [[ -n "$SHOPIFY_CLI_THEME_TOKEN" ]]; then
-  # Use Shopify CLI 3.x
+  log "Using Shopify CLI 3.x"
   export PATH="$npm_config_prefix/bin:$PATH"
 else
-  # Use Shopify CLI 2.x
+  log "Using Shopify CLI 2.x"
   export PATH="$PATH:$npm_config_prefix/bin"
 fi
 
@@ -48,10 +52,6 @@ fi
 
 # Portable code below
 set -eou pipefail
-
-log() {
-  echo "$@" 1>&2
-}
 
 step() {
   cat <<-EOF 1>&2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,7 +188,6 @@ query_string="?preview_theme_id=${preview_id}&_fd=0&pb=0"
 min_score_performance="${LHCI_MIN_SCORE_PERFORMANCE:-0.6}"
 min_score_accessibility="${LHCI_MIN_SCORE_ACCESSIBILITY:-0.9}"
 
-
 cat <<- EOF > lighthouserc.yml
 ci:
   collect:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #51:

1. Lighthouse CI Action is using Shopify CLI 2.x, instead of 3.x
2. Action is depending on _custom_ app, instead of _Theme Access_ app

### WHAT is this pull request doing?

If token for Theme Access app is set, uses CLI 3.x to push theme.
Else, continues to use CLI 2.x with custom app token to push theme.

### How to test your changes?

1. `cd` into repo dir that contains `Dockerfile`
2. Check this repo's README → Authentication to set up _custom_ app token
3. In the script below, write it into `INPUT_ACCESS_TOKEN`
4. Follow the steps in https://shopify.dev/themes/tools/theme-access to set up _Theme Access App_ token
5. In the script below, write it into `INPUT_SHOPIFY_CLI_THEME_TOKEN`
6. Build an image with `podman build --tag lighthouse .` (or `docker …` if you prefer)
7. Execute:
```bash
INPUT_STORE="....myshopify.com"
INPUT_PASSWORD="..." # for password-protected stores
INPUT_ACCESS_TOKEN="..." # for CLI 2.x
INPUT_SHOPIFY_CLI_THEME_TOKEN="..." # for CLI 3.x

podman run --name lighthouse --rm -i -t \
    --mount "type=bind,source=$(pwd)/entrypoint.sh,target=/entrypoint.sh" \
    --mount "type=bind,source=$(pwd)/draft,target=/draft" \
    -e "INPUT_STORE=$INPUT_STORE" \
    -e "INPUT_THEME_ROOT=./draft" \
    -e "INPUT_PASSWORD=$INPUT_PASSWORD" \
    -e "INPUT_ACCESS_TOKEN=$INPUT_ACCESS_TOKEN" \
    -e "INPUT_SHOPIFY_CLI_THEME_TOKEN=$INPUT_SHOPIFY_CLI_THEME_TOKEN" \
    lighthouse
```
8. You should see 3 URLs pointing to `storage.googleapis.com`, in which you can see your Lighthouse performance tests.

### Post-release steps

- [ ] Update https://shopify.dev/themes/tools/lighthouse-ci
- [ ] New release in GitHub