### PR TITLE
Add option for pull_theme and install latest shopify-cli 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM cpclermont/lighthouse-ci-action:1.0.0
+RUN gem uninstall shopify-cli
+RUN gem install shopify-cli -N -n /usr/local/bin
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The `shopify/lighthouse-ci-action` accepts the following arguments:
 * `product_handle` - (optional) Product handle to run the product page Lighthouse run on. Defaults to the first product.
 * `theme_root` - (optional) The root folder for the theme files that will be uploaded. Defaults to `.`
 * `collection_handle` - (optional) Collection handle to run the product page Lighthouse run on. Defaults to the first collection.
+* `pull_theme` - (optional) The ID or name of a theme from which the settings and JSON templates should be used. If not provided Lighthouse will be run against the theme's default settings.
 * `lhci_min_score_performance` - (optional, default: 0.6) Minimum performance score for a passed audit (must be between 0 and 1).
 * `lhci_min_score_accessibility` - (optional, default: 0.9) Minimum accessibility score for a passed audit
 

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: '.'
   pull_theme:
-    description: 'If provided, the settings and json templates will be pulled into the test theme.'
+    description: 'The ID or name of a theme from which the settings and JSON templates should be pulled. If provided, those settings will be pulled into the development theme.'
     required: false
   lhci_github_app_token:
     description: 'Lighthouse CI GitHub app token'

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: 'The root folder for the theme files that will be uploaded (default: ".")'
     required: false
     default: '.'
+  pull_theme:
+    description: 'If provided, the settings and json templates will be pulled into the test theme.'
+    required: false
   lhci_github_app_token:
     description: 'Lighthouse CI GitHub app token'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,7 @@
 [[ -n "$INPUT_PRODUCT_HANDLE" ]]    && export SHOP_PRODUCT_HANDLE="$INPUT_PRODUCT_HANDLE"
 [[ -n "$INPUT_COLLECTION_HANDLE" ]] && export SHOP_COLLECTION_HANDLE="$INPUT_COLLECTION_HANDLE"
 [[ -n "$INPUT_THEME_ROOT" ]]        && export THEME_ROOT="$INPUT_THEME_ROOT"
+[[ -n "$INPUT_PULL_THEME" ]]        && export SHOP_PULL_THEME="$INPUT_PULL_THEME"
 
 # Authentication creds
 export SHOP_ACCESS_TOKEN="$INPUT_ACCESS_TOKEN"
@@ -159,6 +160,12 @@ theme_root="${THEME_ROOT:-.}"
 log "Will run Lighthouse CI on $host"
 
 step "Creating development theme"
+
+if [[ -n "${SHOP_PULL_THEME+x}" ]]; then
+  log "Pulling settings from theme $SHOP_PULL_THEME"
+  shopify theme pull --theme ${SHOP_PULL_THEME} --only templates/*.json --only config/settings_data.json
+fi
+
 theme_push_log="$(mktemp)"
 shopify theme push --development --json $theme_root > "$theme_push_log" && cat "$theme_push_log"
 preview_url="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.preview_url')"


### PR DESCRIPTION
### Summary

* Adds an optional param for `pull_theme` which, if provided, will pull the JSON templates and settings values for a specified theme
* Update Dockerfile to reinstall `shopify-cli` gem. The image has an older version of shopify-cli (2.0.1) that is missing key `theme pull` options

### Why I'm adding it

On the Theme Design team we need to track lighthouse scores for realistic storefronts, e.g. those with image heroes and many sections. We also may need to test different configurations (various combinations of sections, menu styles, etc.) However, the lighthouse action currently only tests against the default settings of a theme.

### Approach taken

1. Uninstalls the existing `shopify-cli` gem and reinstalls the latest version. I found this was preferable to rebuilding and re-hosting the docker image with a new `shopify-cli` install but I'm open to it if there's someone available to assist.
2. Checks for a `pull_theme` option passed to the github action. This should be a theme name or theme ID, same as `shopify theme pull --theme`.
3. If `pull_theme` exists it triggers an extra step in the script to pull the theme settings.

### Testing instructions

Add a CI job to a theme pointing to the latest SHA in this PR:

```
name: CI
on: [push]
jobs:
  lhci:
    name: Lighthouse
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Lighthouse
        uses: shopify/lighthouse-ci-action@f63f6c39a4cb6fb40169194dcf51eac62354651c
        with:
          store: ${{ secrets.SHOP_STORE_OS2 }}
          password: ${{ secrets.SHOP_PASSWORD_OS2 }}
          access_token: ${{ secrets.SHOP_ACCESS_TOKEN }}
          pull_theme: ${{ secrets.SHOP_PULL_THEME }}
          product_handle: the-organic-cotton-cutaway-tank
          collection_handle: all
          lhci_github_app_token: ${{ secrets.LHCI_GITHUB_TOKEN }}
```

Run the lighthouse-ci action, e.g. by posting a new PR.

Check the lighthouse reports generated by the action. Confirm that the settings from the theme specified were pulled successfully.