### PR TITLE
fix: missing theme_root on theme pull

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -163,7 +163,7 @@ step "Creating development theme"
 
 if [[ -n "${SHOP_PULL_THEME+x}" ]]; then
   log "Pulling settings from theme $SHOP_PULL_THEME"
-  shopify theme pull --theme ${SHOP_PULL_THEME} --only templates/*.json --only config/settings_data.json
+  shopify theme pull --theme ${SHOP_PULL_THEME} --only templates/*.json --only config/settings_data.json $theme_root
 fi
 
 theme_push_log="$(mktemp)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -163,7 +163,7 @@ step "Creating development theme"
 
 if [[ -n "${SHOP_PULL_THEME+x}" ]]; then
   log "Pulling settings from theme $SHOP_PULL_THEME"
-  shopify theme pull --theme ${SHOP_PULL_THEME} --only templates/*.json --only config/settings_data.json $theme_root
+  shopify theme pull $theme_root --theme ${SHOP_PULL_THEME} --only templates/*.json --only config/settings_data.json
 fi
 
 theme_push_log="$(mktemp)"


### PR DESCRIPTION
`pull_theme` feature added in [#57](https://github.com/Shopify/lighthouse-ci-action/pull/57) is not using the `theme_root` config.

This causing the action to be stuck indefinitely after executing the `shopify theme pull` command if we use both `pull_theme` and a custom path for `theme_root` because the CLI is not able to find the theme and is waiting for user input.