### PR TITLE
Update base Dockerimage ruby to 3.1.4 for the latest Shopify CLI 3.x

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,8 +8,8 @@ RUN apt-get update \
     && mkdir -p "$(rbenv root)"/plugins \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 2.7.1 \
-    && rbenv global 2.7.1 \
+    && rbenv install 3.1.4 \
+    && rbenv global 3.1.4 \
     && gem install shopify-cli -N
 
 ###


### PR DESCRIPTION
In order to support the latest Shopify CLI 3.x, we need to update the global ruby version to 3.1.4

When we run in with the existing ruby version `2.7.1`, I was getting the following error:
```
Your environment Ruby version, 2.7.1, is outside of the range supported by the CLI, 2.7.5..<3.2.0, and might cause incompatibility issues.
```

Therefore, updating the base ruby to version 3.1.4 will allow us to leverage the latest Shopify 3.x version

REF:
<img width="1132" alt="Screenshot 2023-10-23 at 8 53 15 pm" src="https://github.com/Shopify/lighthouse-ci-action/assets/6029549/a8947296-007c-40b4-8bcc-67f9563b443f">
