### PR TITLE
Update action to Shopify CLI 3, lhci 0.13 and ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,30 +11,12 @@ jobs:
         include:
           - job_name: 'staff store, custom app login'
             store: shimmering-islands.myshopify.com
-            app_id: ''
-            app_password: ''
             access_token: SHOP_ACCESS_TOKEN
-            password: ''
-
-          - job_name: 'staff store, private app login'
-            store: shimmering-islands.myshopify.com
-            app_id: SHOP_APP_ID
-            app_password: SHOP_APP_PASSWORD
-            access_token: ''
             password: ''
 
           - job_name: 'dev store, custom app login'
             store: cpclermont-dev-store.myshopify.com
-            app_id: ''
-            app_password: DEV_APP_PASSWORD
             access_token: DEV_ACCESS_TOKEN
-            password: DEV_PASSWORD
-
-          - job_name: 'dev store, private app login'
-            store: cpclermont-dev-store.myshopify.com
-            app_id: DEV_APP_ID
-            app_password: DEV_APP_PASSWORD
-            access_token: ''
             password: DEV_PASSWORD
 
     name: ${{ matrix.job_name }}
@@ -50,8 +32,6 @@ jobs:
         uses: ./
         id: lighthouse-ci-action
         with:
-          app_id: ${{ secrets[matrix.app_id] }}
-          app_password: ${{ secrets[matrix.app_password] }}
           access_token: ${{ secrets[matrix.access_token] }}
           store: ${{ matrix.store }}
           password: ${{ secrets[matrix.password] }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,5 @@
-FROM node:14-buster
-
-ENV PATH="/root/.rbenv/shims:${PATH}"
-
-# Install dependencies
-RUN apt-get update \
-    && apt-get -y install sudo jq rbenv \
-    && mkdir -p "$(rbenv root)"/plugins \
-    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
-    && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 3.2.0 \
-    && rbenv global 3.2.0 \
-    && gem install shopify-cli -N
-
-###
-# Chrome in Docker fix
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
-ENV PATH="$npm_config_prefix:${PATH}"
-RUN mkdir -p "$npm_config_prefix" \
-  && chmod -R 777 "$npm_config_prefix" \
-  && umask 000 \
-  && npm install -g @lhci/cli@0.8.x puppeteer
+FROM cpclermont/lighthouse-ci-action:1.0.0
+RUN gem uninstall shopify-cli
+RUN gem install shopify-cli -N -n /usr/local/bin
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,22 @@ RUN apt-get update \
     && rbenv install 3.2.0 \
     && rbenv global 3.2.0
 
+# Install latest chrome stable package.
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update \
+    && apt-get install -y google-chrome-stable --no-install-recommends \
+    && apt-get clean
+
+# install puppeteer and stuff
 ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
 ENV PATH="$npm_config_prefix:${PATH}"
 RUN mkdir -p "$npm_config_prefix" \
   && chmod -R 777 "$npm_config_prefix" \
   && umask 000 \
-  && npm install -g @lhci/cli@0.13.x puppeteer \
-  && npx puppeteer browsers install chrome
+  && npm install -g @lhci/cli@0.13.x lighthouse puppeteer
+
+# RUN npx puppeteer browsers install chrome
 
 # every time
 RUN npm install -g @shopify/cli @shopify/theme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-buster
+FROM node:18-buster
 
 ENV PATH="/root/.rbenv/shims:${PATH}"
 
@@ -11,25 +11,13 @@ RUN apt-get update \
     && rbenv install 3.2.0 \
     && rbenv global 3.2.0
 
-###
-# Chrome in Docker fix
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
-RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
-
 ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
 ENV PATH="$npm_config_prefix:${PATH}"
 RUN mkdir -p "$npm_config_prefix" \
   && chmod -R 777 "$npm_config_prefix" \
   && umask 000 \
-  && npm install -g @lhci/cli@0.8.x puppeteer
+  && npm install -g @lhci/cli@0.13.x puppeteer \
+  && npx puppeteer browsers install chrome
 
 # every time
 RUN npm install -g @shopify/cli @shopify/theme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,37 @@
-FROM cpclermont/lighthouse-ci-action:1.0.0
-RUN gem uninstall shopify-cli
-RUN gem install shopify-cli -N -n /usr/local/bin
+FROM node:20-buster
+
+ENV PATH="/root/.rbenv/shims:${PATH}"
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get -y install sudo jq rbenv \
+    && mkdir -p "$(rbenv root)"/plugins \
+    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
+    && git -C "$(rbenv root)"/plugins/ruby-build pull \
+    && rbenv install 3.2.0 \
+    && rbenv global 3.2.0
+
+###
+# Chrome in Docker fix
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
+ENV PATH="$npm_config_prefix:${PATH}"
+RUN mkdir -p "$npm_config_prefix" \
+  && chmod -R 777 "$npm_config_prefix" \
+  && umask 000 \
+  && npm install -g @lhci/cli@0.8.x puppeteer
+
+# every time
+RUN npm install -g @shopify/cli @shopify/theme
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
     && mkdir -p "$(rbenv root)"/plugins \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 3.1.4 \
-    && rbenv global 3.1.4 \
+    && rbenv install 3.2.0 \
+    && rbenv global 3.2.0 \
     && gem install shopify-cli -N
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
     && mkdir -p "$(rbenv root)"/plugins \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 3.0.0 \
-    && rbenv global 3.0.0 \
+    && rbenv install 3.1.4 \
+    && rbenv global 3.1.4 \
     && gem install shopify-cli -N
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,33 @@
-FROM cpclermont/lighthouse-ci-action:1.0.0
-RUN gem uninstall shopify-cli
-RUN gem install shopify-cli -N -n /usr/local/bin
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+FROM node:14-buster
+
+ENV PATH="/root/.rbenv/shims:${PATH}"
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get -y install sudo jq rbenv \
+    && mkdir -p "$(rbenv root)"/plugins \
+    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
+    && git -C "$(rbenv root)"/plugins/ruby-build pull \
+    && rbenv install 3.0.0 \
+    && rbenv global 3.0.0 \
+    && gem install shopify-cli -N
+
+###
+# Chrome in Docker fix
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
+ENV PATH="$npm_config_prefix:${PATH}"
+RUN mkdir -p "$npm_config_prefix" \
+  && chmod -R 777 "$npm_config_prefix" \
+  && umask 000 \
+  && npm install -g @lhci/cli@0.8.x puppeteer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,4 @@
-FROM node:18-buster
-
-ENV PATH="/root/.rbenv/shims:${PATH}"
-
-# Install dependencies
-RUN apt-get update \
-    && apt-get -y install sudo jq rbenv \
-    && mkdir -p "$(rbenv root)"/plugins \
-    && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
-    && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 3.2.0 \
-    && rbenv global 3.2.0
-
-# Install latest chrome stable package.
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update \
-    && apt-get install -y google-chrome-stable --no-install-recommends \
-    && apt-get clean
-
-# install puppeteer and stuff
-ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
-ENV PATH="$npm_config_prefix:${PATH}"
-RUN mkdir -p "$npm_config_prefix" \
-  && chmod -R 777 "$npm_config_prefix" \
-  && umask 000 \
-  && npm install -g @lhci/cli@0.13.x lighthouse puppeteer
-
-# RUN npx puppeteer browsers install chrome
-
-# every time
+FROM cpclermont/lighthouse-ci-action:2.0.0
 RUN npm install -g @shopify/cli @shopify/theme
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,8 +8,8 @@ RUN apt-get update \
     && mkdir -p "$(rbenv root)"/plugins \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 2.7.5 \
-    && rbenv global 2.7.5 \
+    && rbenv install 3.0.0 \
+    && rbenv global 3.0.0 \
     && gem install shopify-cli -N
 
 ###

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,8 +8,8 @@ RUN apt-get update \
     && mkdir -p "$(rbenv root)"/plugins \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 3.1.4 \
-    && rbenv global 3.1.4 \
+    && rbenv install 3.2.0 \
+    && rbenv global 3.2.0 \
     && gem install shopify-cli -N
 
 ###

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -8,8 +8,8 @@ RUN apt-get update \
     && mkdir -p "$(rbenv root)"/plugins \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
-    && rbenv install 3.0.0 \
-    && rbenv global 3.0.0 \
+    && rbenv install 3.1.4 \
+    && rbenv global 3.1.4 \
     && gem install shopify-cli -N
 
 ###

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM node:14-buster
+FROM node:18-buster
 
 ENV PATH="/root/.rbenv/shims:${PATH}"
 
@@ -9,25 +9,19 @@ RUN apt-get update \
     && git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build \
     && git -C "$(rbenv root)"/plugins/ruby-build pull \
     && rbenv install 3.2.0 \
-    && rbenv global 3.2.0 \
-    && gem install shopify-cli -N
+    && rbenv global 3.2.0
 
-###
-# Chrome in Docker fix
-# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+# Install latest chrome stable package.
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 RUN apt-get update \
-    && apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y google-chrome-stable --no-install-recommends \
+    && apt-get clean
 
+# install puppeteer and stuff
 ENV npm_config_prefix="$GITHUB_WORKSPACE/.node"
 ENV PATH="$npm_config_prefix:${PATH}"
 RUN mkdir -p "$npm_config_prefix" \
   && chmod -R 777 "$npm_config_prefix" \
   && umask 000 \
-  && npm install -g @lhci/cli@0.8.x puppeteer
+  && npm install -g @lhci/cli@0.13.x lighthouse puppeteer

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := cpclermont/lighthouse-ci-action
-VERSION := 1.0.0
+VERSION := 2.0.0
 GITSHA:= $(shell echo $$(git describe --always --long --dirty))
 
 export GITSHA

--- a/README.md
+++ b/README.md
@@ -66,10 +66,3 @@ For the GitHub Status Checks on PR. One of the two arguments is required:
 * `lhci_github_token` - (optional) GitHub personal access token
 
 For more details on the implications of choosing one over the other, refer to the [Lighthouse CI Getting Started Page](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/getting-started.md#github-status-checks)
-
-### Deprecated authentication configuration
-
-The following were used to authenticate with private apps.
-
-* `app_id` - (deprecated) Shopify store private app ID.
-* `app_password` - (deprecated) Shopify store private app password.

--- a/action.yml
+++ b/action.yml
@@ -43,14 +43,6 @@ inputs:
     description: 'Minimum accessibility score'
     required: false
     default: 0.9
-  app_id:
-    description: '(deprecated) Shopify private app ID'
-    depreciationMessage: Shopify private apps are deprecated. Use a Custom App `access_token` instead.
-    required: false
-  app_password:
-    description: '(deprecated) Shopify private app password'
-    depreciationMessage: Shopify private apps are deprecated. Use a Custom App `access_token` instead.
-    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,9 +181,11 @@ query_string="?preview_theme_id=${preview_id}&_fd=0&pb=0"
 min_score_performance="${LHCI_MIN_SCORE_PERFORMANCE:-0.6}"
 min_score_accessibility="${LHCI_MIN_SCORE_ACCESSIBILITY:-0.9}"
 
-# that's where the browser is installed
+# Env vars for puppeteer to work with our chrome install
+# See https://pptr.dev/api/puppeteer.configuration
 # export PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
 export PUPPETEER_EXECUTABLE_PATH='/usr/bin/google-chrome-stable'
+export LHCI_BUILD_CONTEXT__CURRENT_HASH="$GITHUB_SHA"
 
 cat <<- EOF > lighthouserc.yml
 ci:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,12 +54,6 @@ step() {
 	EOF
 }
 
-is_installed() {
-  # This works with scripts and programs. For more info, check
-  # http://goo.gl/B9683D
-  type $1 &> /dev/null 2>&1
-}
-
 api_request() {
   local url="$1"
   local err="$(mktemp)"
@@ -118,18 +112,6 @@ cleanup() {
 }
 
 trap 'cleanup $?' EXIT
-
-if ! is_installed lhci; then
-  step "Installing Lighthouse CI"
-  log npm install -g @lhci/cli@0.7.x puppeteer
-  npm install -g @lhci/cli@0.7.x puppeteer
-fi
-
-if ! is_installed shopify; then
-  step "Installing Shopify CLI"
-  log "gem install shopify"
-  gem install shopify
-fi
 
 step "Configuring shopify CLI"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -181,6 +181,10 @@ query_string="?preview_theme_id=${preview_id}&_fd=0&pb=0"
 min_score_performance="${LHCI_MIN_SCORE_PERFORMANCE:-0.6}"
 min_score_accessibility="${LHCI_MIN_SCORE_ACCESSIBILITY:-0.9}"
 
+# that's where the browser is installed
+# export PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
+export PUPPETEER_EXECUTABLE_PATH='/usr/bin/google-chrome-stable'
+
 cat <<- EOF > lighthouserc.yml
 ci:
   collect:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -131,7 +131,10 @@ else
   export SHOPIFY_PASSWORD="$SHOP_APP_PASSWORD"
 fi
 
-shopify login
+export SHOPIFY_FLAG_STORE="$SHOPIFY_SHOP"
+export SHOPIFY_CLI_THEME_TOKEN="$SHOPIFY_PASSWORD"
+export SHOPIFY_CLI_TTY=0
+# shopify auth login
 
 host="https://${SHOP_STORE#*(https://|http://)}"
 theme_root="${THEME_ROOT:-.}"
@@ -149,9 +152,9 @@ if [[ -n "${SHOP_PULL_THEME+x}" ]]; then
 fi
 
 theme_push_log="$(mktemp)"
-shopify theme push --development --json $theme_root > "$theme_push_log" && cat "$theme_push_log"
-preview_url="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.preview_url')"
-preview_id="$(cat "$theme_push_log" | tail -n 1 | jq -r '.theme.id')"
+shopify theme push --development --json --path $theme_root > "$theme_push_log" && cat "$theme_push_log"
+preview_url="$(cat "$theme_push_log" | jq -r '.theme.preview_url')"
+preview_id="$(cat "$theme_push_log" | jq -r '.theme.id')"
 
 step "Configuring Lighthouse CI"
 


### PR DESCRIPTION
- https://github.com/Shopify/lighthouse-ci-action/issues/76

Bump installed Ruby Version to 3.2.0  to satisfy `Nokigiri` dependancy (more context in issue)
[Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/)

### Why did this happen?
`Nokogiri` is included as a dependancy via `shopify-theme-check`, so this started to break since the [latest release](https://github.com/sparklemotion/nokogiri/releases/tag/v1.16.0) ended support for Ruby 2.7

We **could** consider freezing the version in the [gemspec for theme_check](https://github.com/Shopify/theme-check/blame/e7bbb91eb35feafc392712cdc7e00d42ef8d558c/theme-check.gemspec#L30), but that would come with the tradeoff of not receiving future updates

### Why Version 3.2.0?
- `Nokigiri` requires > version `3.0.0`, but `3.0.0` is approaching EOL in March 2024
- This is the highest version that is supported by both [CLI 2](https://github.com/Shopify/shopify-cli/blob/fb29caa8a88d16b67eaa22bc31a83ad7cbfd157f/lib/shopify_cli/constants.rb#L66-L70) and [CLI 3](https://github.com/Shopify/cli/blob/33c65554fb82f9d9a4a3da8aa3911708a5309dd7/packages/cli-kit/assets/cli-ruby/lib/shopify_cli/constants.rb#L70-L75)

### Validating this change
- View the `CI` workflow results [here](https://github.com/Shopify/lighthouse-ci-action/actions/runs/7417465737) 
  _- We execute this action on PRs in this repo so that we can validate behaviour_
  
<img width="1508" alt="image" src="https://github.com/Shopify/lighthouse-ci-action/assets/35415298/d199e18c-f86b-44a0-b3dd-48154273d10e">

### More notes
- Migrated code to Shopify/cli 3 (from shopify/cli 2.x)
- Bumped lhci to 0.13.x because... you know we should have a while ago 😅 