### PR TITLE
Silence NodeJS Version Warning: Update GitHub Actions checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     name: ${{ matrix.job_name }}
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: "shopify/dawn"
           path: "./dawn"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Lighthouse
         uses: shopify/lighthouse-ci-action@v1
         with:


### PR DESCRIPTION
Silences the following warning annotation when running the CI workflow.

![image](https://github.com/Shopify/lighthouse-ci-action/assets/35415298/e520206a-ed06-4fe2-825d-913683a28b38)

This annotation came from using the `checkout@v2` to checkout the repository, which relies on a now unsupported version of Node (12).

Updating this to the latest version of checkout found below
[Checkout · Actions · GitHub Marketplace](https://github.com/marketplace/actions/checkout)

### Verifying this change
- View the CI workflow execution under the 'actions' tab on this PR


### Note:
- Checks will continue to fail until [Bump Ruby Version to 3.3.0 by jamesmengo · Pull Request #77 · Shopify/lighthouse-ci-action](https://github.com/Shopify/lighthouse-ci-action/pull/77) is shipped