### PR TITLE
Mark github directory as safe for git commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -147,6 +147,11 @@ log "Will run Lighthouse CI on $host"
 step "Creating development theme"
 
 if [[ -n "${SHOP_PULL_THEME+x}" ]]; then
+  # `shopify theme pull` now includes Git commands and so we need to mark the
+  # directory as safe.
+  log "Marking the Github directory as safe for Git"
+  git config --global --add safe.directory $GITHUB_WORKSPACE
+
   log "Pulling settings from theme $SHOP_PULL_THEME"
   shopify theme pull --path "$theme_root" --theme ${SHOP_PULL_THEME} --only templates/*.json --only config/settings_data.json
 fi


### PR DESCRIPTION
Fixes an issue that users will see that looks like this:

```
Pulling settings from theme ***
╭─ error ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  fatal: detected dubious ownership in repository at '/github/workspace'      │
│  To add an exception for this directory, call:                               │
│                                                                              │
│  	git config --global --add safe.directory /github/workspace                 │
│                                                                              │
│                                                                              │
│  To investigate the issue, examine this stack trace:                         │
│    at action                                                                 │
│    (.node/lib/node_modules/@shopify/cli/dist/chunk-NHV2E73I.js:137107)       │
│    at exec                                                                   │
│    (.node/lib/node_modules/@shopify/cli/dist/chunk-NHV2E73I.js:137127)       │
│    at (.node/lib/node_modules/@shopify/cli/dist/chunk-NHV2E73I.js:135339)    │
│    at new Promise                                                            │
│    at handleTaskData                                                         │
│    (.node/lib/node_modules/@shopify/cli/dist/chunk-NHV2E73I.js:135337)       │
│    at <anonymous>                                                            │
│    (.node/lib/node_modules/@shopify/cli/dist/chunk-NHV2E73I.js:135326)       │
│    at next                                                                   │
│    at fulfilled                                                              │
│    (.node/lib/node_modules/@shopify/cli/dist/chunk-NHV2E73I.js:1345[19](https://github.com/Shopify/dawn/actions/runs/12775837814/job/35613129162#step:4:20))       │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

As of v3.73.0 in the Shopify CLI the `shopify theme pull` command utilizes Git to check if the working directory is clean. This command triggers this in Git:

> A change was introduced in git 2.35.2 (and newer) to prevent a user from executing git commands in a repository owned by a different user.

GitHub does this by default for Actions but because this action runs inside of a container we need to explicitly say that it's safe.