### PR TITLE
Part 2: Switch Dockerfile and Makefile to ghcr.io base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cpclermont/lighthouse-ci-action:2.0.0
+FROM ghcr.io/shopify/lighthouse-ci-action:3.0.0
 RUN npm install -g @shopify/cli @shopify/theme
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PROJECT_NAME := cpclermont/lighthouse-ci-action
-VERSION := 2.0.0
+PROJECT_NAME := ghcr.io/shopify/lighthouse-ci-action
+VERSION := 3.0.0
 GITSHA:= $(shell echo $$(git describe --always --long --dirty))
 
 export GITSHA


### PR DESCRIPTION
## Summary

Part 2 of the ghcr.io migration (#103). Depends on #104 being merged first so the `ghcr.io/shopify/lighthouse-ci-action:3.0.0` image exists.

- Updates `Dockerfile` from `cpclermont/lighthouse-ci-action:2.0.0` to `ghcr.io/shopify/lighthouse-ci-action:3.0.0`
- Updates `Makefile` to match the new registry and version

### Merge order

1. Merge #104 (adds the build workflow + updates `Dockerfile.base`)
2. Wait for the `build-base-image` workflow to push the `3.0.0` image to ghcr.io
3. Merge this PR