### PR TITLE
Fix Chrome GPG key import for Bookworm

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -12,7 +12,7 @@ RUN apt-get update \
     && rbenv global 3.2.0
 
 # Install latest chrome stable package (using signed-by for Bookworm compatibility).
-RUN wget -q -O /usr/share/keyrings/google-chrome.gpg https://dl-ssl.google.com/linux/linux_signing_key.pub \
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get install -y google-chrome-stable --no-install-recommends \


### PR DESCRIPTION
## Summary

Fixes the `build-base-image` workflow failure from #104. 

The raw Google signing key needs to be piped through `gpg --dearmor` to produce a binary keyring file that the `signed-by` APT directive can use. Without dearmoring, apt can't verify the Chrome repo signature:

```
GPG error: http://dl.google.com/linux/chrome/deb stable InRelease:
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 32EE5355A6BC6E42
```