### PR TITLE
feat: add optional best-practices and SEO score thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The `shopify/lighthouse-ci-action` accepts the following arguments:
 * `pull_theme` - The ID or name of a theme from which the settings and JSON templates should be used. If not provided Lighthouse will be run against the theme's default settings.
 * `lhci_min_score_performance` - (default: 0.6) Minimum performance score for a passed audit (must be between 0 and 1).
 * `lhci_min_score_accessibility` - (default: 0.9) Minimum accessibility score for a passed audit
+* `lhci_min_score_best_practices` - (optional) Minimum best practices score for a passed audit. Not asserted if omitted.
+* `lhci_min_score_seo` - (optional) Minimum SEO score for a passed audit. Not asserted if omitted.
 
 For the GitHub Status Checks on PR. One of the two arguments is required:
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,12 @@ inputs:
     description: 'Minimum accessibility score'
     required: false
     default: 0.9
+  lhci_min_score_best_practices:
+    description: 'Minimum best practices score (not asserted if omitted)'
+    required: false
+  lhci_min_score_seo:
+    description: 'Minimum SEO score (not asserted if omitted)'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,8 +32,10 @@
 [[ -n "$INPUT_LHCI_GITHUB_TOKEN" ]]     && export LHCI_GITHUB_TOKEN="$INPUT_LHCI_GITHUB_TOKEN"
 
 # Optional, these are used
-[[ -n "$INPUT_LHCI_MIN_SCORE_PERFORMANCE" ]]   && export LHCI_MIN_SCORE_PERFORMANCE="$INPUT_LHCI_MIN_SCORE_PERFORMANCE"
-[[ -n "$INPUT_LHCI_MIN_SCORE_ACCESSIBILITY" ]] && export LHCI_MIN_SCORE_ACCESSIBILITY="$INPUT_LHCI_MIN_SCORE_ACCESSIBILITY"
+[[ -n "$INPUT_LHCI_MIN_SCORE_PERFORMANCE" ]]    && export LHCI_MIN_SCORE_PERFORMANCE="$INPUT_LHCI_MIN_SCORE_PERFORMANCE"
+[[ -n "$INPUT_LHCI_MIN_SCORE_ACCESSIBILITY" ]]  && export LHCI_MIN_SCORE_ACCESSIBILITY="$INPUT_LHCI_MIN_SCORE_ACCESSIBILITY"
+[[ -n "$INPUT_LHCI_MIN_SCORE_BEST_PRACTICES" ]] && export LHCI_MIN_SCORE_BEST_PRACTICES="$INPUT_LHCI_MIN_SCORE_BEST_PRACTICES"
+[[ -n "$INPUT_LHCI_MIN_SCORE_SEO" ]]            && export LHCI_MIN_SCORE_SEO="$INPUT_LHCI_MIN_SCORE_SEO"
 
 # Add global node bin to PATH (from the Dockerfile)
 export PATH="$PATH:$npm_config_prefix/bin"
@@ -235,6 +237,8 @@ fi
 query_string="?preview_theme_id=${preview_id}&_fd=0&pb=0"
 min_score_performance="${LHCI_MIN_SCORE_PERFORMANCE:-0.6}"
 min_score_accessibility="${LHCI_MIN_SCORE_ACCESSIBILITY:-0.9}"
+min_score_best_practices="${LHCI_MIN_SCORE_BEST_PRACTICES:-}"
+min_score_seo="${LHCI_MIN_SCORE_SEO:-}"
 
 # Env vars for puppeteer to work with our chrome install
 # See https://pptr.dev/api/puppeteer.configuration
@@ -269,6 +273,21 @@ ci:
         - minScore: $min_score_accessibility
           aggregationMethod: median-run
 EOF
+
+# Append optional category assertions
+if [[ -n "$min_score_best_practices" ]]; then
+  echo '      "categories:best-practices":' >> lighthouserc.yml
+  echo '        - error' >> lighthouserc.yml
+  echo "        - minScore: $min_score_best_practices" >> lighthouserc.yml
+  echo '          aggregationMethod: median-run' >> lighthouserc.yml
+fi
+
+if [[ -n "$min_score_seo" ]]; then
+  echo '      "categories:seo":' >> lighthouserc.yml
+  echo '        - error' >> lighthouserc.yml
+  echo "        - minScore: $min_score_seo" >> lighthouserc.yml
+  echo '          aggregationMethod: median-run' >> lighthouserc.yml
+fi
 
 cat <<-EOF > setPreviewCookies.js
 module.exports = async (browser) => {


### PR DESCRIPTION
## Summary

Adds two new optional inputs for asserting Lighthouse best-practices and SEO scores:

- `lhci_min_score_best_practices` — minimum best practices score (not asserted if omitted)
- `lhci_min_score_seo` — minimum SEO score (not asserted if omitted)

These follow the same pattern as the existing `lhci_min_score_performance` and `lhci_min_score_accessibility` inputs. They are fully optional with no defaults, so existing workflows are unaffected.

## Why

Lighthouse audits already run best-practices and SEO checks, but the action only lets you set pass/fail thresholds for performance and accessibility. Theme developers who want CI gates for all four Lighthouse categories currently have no way to do so without a custom lighthouserc.yml.

## Usage

```yml
- uses: shopify/lighthouse-ci-action@v1
  with:
    store: $\{{ secrets.SHOP_STORE }}
    client_id: $\{{ secrets.SHOP_CLIENT_ID }}
    client_secret: $\{{ secrets.SHOP_CLIENT_SECRET }}
    lhci_min_score_performance: 0.6
    lhci_min_score_accessibility: 0.9
    lhci_min_score_best_practices: 0.7
    lhci_min_score_seo: 0.9
```

## Implementation

- New inputs are appended as assertions to `lighthouserc.yml` only when provided (keeps the heredoc clean and avoids empty assertions)
- Follows existing code patterns for input mapping and variable defaults
- Backwards compatible — no changes to default behavior

## Testing

Validated in production CI on a Shopify store ([zookanalytics/altareina](https://github.com/zookanalytics/altareina)) with all four categories configured and passing.
