### PR TITLE
Fix: pass --no-sandbox flags to Lighthouse Chrome launcher

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -249,8 +249,7 @@ ci:
       - "$host/$query_string"
       - "$host/products/$product_handle$query_string"
       - "$host/collections/$collection_handle$query_string"
-    settings:
-      chromeFlags: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu'
+    chromeFlags: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu'
     puppeteerScript: './setPreviewCookies.js'
     puppeteerLaunchOptions:
       args:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -236,10 +236,18 @@ query_string="?preview_theme_id=${preview_id}&_fd=0&pb=0"
 min_score_performance="${LHCI_MIN_SCORE_PERFORMANCE:-0.6}"
 min_score_accessibility="${LHCI_MIN_SCORE_ACCESSIBILITY:-0.9}"
 
-# Env vars for puppeteer to work with our chrome install
-# See https://pptr.dev/api/puppeteer.configuration
-# export PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
-export PUPPETEER_EXECUTABLE_PATH='/usr/bin/google-chrome-stable'
+# Create a Chrome wrapper that always passes --no-sandbox.
+# Required when running as root in Docker (Chrome 112+ refuses root without it).
+# Both PUPPETEER_EXECUTABLE_PATH and CHROME_PATH (used by chrome-launcher) point
+# here so every Chrome launch — Puppeteer and Lighthouse — picks up the flag.
+cat > /usr/local/bin/chrome-no-sandbox <<'CHROME_WRAPPER'
+#!/bin/sh
+exec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu "$@"
+CHROME_WRAPPER
+chmod +x /usr/local/bin/chrome-no-sandbox
+
+export PUPPETEER_EXECUTABLE_PATH='/usr/local/bin/chrome-no-sandbox'
+export CHROME_PATH='/usr/local/bin/chrome-no-sandbox'
 export LHCI_BUILD_CONTEXT__CURRENT_HASH="$GITHUB_SHA"
 
 cat <<- EOF > lighthouserc.yml
@@ -249,7 +257,7 @@ ci:
       - "$host/$query_string"
       - "$host/products/$product_handle$query_string"
       - "$host/collections/$collection_handle$query_string"
-    chromeFlags: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu'
+    chromePath: '/usr/local/bin/chrome-no-sandbox'
     puppeteerScript: './setPreviewCookies.js'
     puppeteerLaunchOptions:
       args:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -249,6 +249,8 @@ ci:
       - "$host/$query_string"
       - "$host/products/$product_handle$query_string"
       - "$host/collections/$collection_handle$query_string"
+    settings:
+      chromeFlags: '--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu'
     puppeteerScript: './setPreviewCookies.js'
     puppeteerLaunchOptions:
       args:


### PR DESCRIPTION
## Problem

The generated \`lighthouserc.yml\` already passes \`--no-sandbox\` and related flags via \`puppeteerLaunchOptions\`, but those only apply to the **Puppeteer browser** used to set preview cookies. The actual Lighthouse audit runs a **separate Chrome process** via \`LH:ChromeLauncher\`, which does not inherit those flags.

When the action runs in a Docker container as root (the default on GitHub-hosted runners), Chrome 147+ exits immediately with:

\`\`\`
LH:ChromeLauncher:error [167:167:...] Running as root without --no-sandbox is not supported.
See https://crbug.com/638180.
\`\`\`

This causes \`lhci collect\` to fail with \`Run #1...failed!\` and \`Error: Lighthouse failed with exit code 1\`. The failure is environment-dependent — runners with a more permissive seccomp profile will pass, making the failure appear flaky.

## Root cause

\`chromeFlags\` in \`lighthouserc.yml\` (whether under \`collect\` or \`collect.settings\`) is not reliably picked up by chrome-launcher. The reliable path is the \`CHROME_PATH\` environment variable, which chrome-launcher uses to locate and launch Chrome.

## Fix

Create a wrapper script that unconditionally prepends \`--no-sandbox\` to every Chrome launch, then point both \`PUPPETEER_EXECUTABLE_PATH\` and \`CHROME_PATH\` at it:

\`\`\`bash
cat > /usr/local/bin/chrome-no-sandbox <<'WRAPPER'
#!/bin/sh
exec /usr/bin/google-chrome-stable --no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu "$@"
WRAPPER
chmod +x /usr/local/bin/chrome-no-sandbox

export PUPPETEER_EXECUTABLE_PATH='/usr/local/bin/chrome-no-sandbox'
export CHROME_PATH='/usr/local/bin/chrome-no-sandbox'
\`\`\`

Also set \`collect.chromePath\` in \`lighthouserc.yml\` as a belt-and-suspenders fallback for any LHCI code path that reads config instead of env.

This means every Chrome launch in the action — Puppeteer cookie setup and Lighthouse audits — goes through the same wrapper and always has \`--no-sandbox\`.

## Testing

- Confirmed the original error reproduced 7 consecutive times on \`yrf8g3-i4.myshopify.com\` (Shopify Atelier theme) with \`shopify/lighthouse-ci-action@v1.4.0\` and Chrome \`147.0.7727.116-1\` on \`ubuntu-24.04\` runner image \`20260413.86.1\`.
- Confirmed this fix passes end-to-end (Theme Check → Lint → Secret Scan → Deploy Staging → **Lighthouse CI ✅** → Deploy Production ✅) on the same store using \`tsira/lighthouse-ci-action@fix/chrome-no-sandbox-for-lighthouse-audit\`: https://github.com/tsira/kwd/actions/runs/24977466455

🤖 Generated with [Claude Code](https://claude.com/claude-code)