### PR TITLE
Update Dockerfile to Node 22, remove deprecated @shopify/theme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm
+FROM node:22-bookworm
 
 # Install system dependencies
 RUN apt-get update \
@@ -21,7 +21,7 @@ RUN mkdir -p "$npm_config_prefix" \
   && npm install -g @lhci/cli@0.13.x lighthouse puppeteer
 
 # Install Shopify CLI
-RUN npm install -g @shopify/cli @shopify/theme
+RUN npm install -g @shopify/cli
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary

The Dockerfile currently uses `node:20-bookworm`, which limits `@shopify/cli` to the 3.x branch (4.x requires Node >=22.12.0). This causes `shopify theme push` to fail when block or section schemas use `color_palette` dynamic defaults (e.g. `{{ settings.colors.foreground }}`).

This was fixed in `@shopify/cli` 4.0.0 — specifically [1e8963e](https://github.com/Shopify/cli/commit/1e8963e), which uploads `config/settings_schema.json` before any other theme file so that blocks/sections referencing `color_palette` settings resolve correctly on first push. However, 4.0.0 also dropped Node 20 support ([0c35553](https://github.com/Shopify/cli/commit/0c35553)), so the fix is unreachable from a Node 20 base image.

### Changes

- `FROM node:20-bookworm` → `FROM node:22-bookworm`
- Removed `@shopify/theme` from `npm install -g` (deprecated since CLI 3.59.0, now bundled in `@shopify/cli`)